### PR TITLE
[ CHG ] Change edit course link on admin show

### DIFF
--- a/app/views/administrators/courses/show.html.erb
+++ b/app/views/administrators/courses/show.html.erb
@@ -15,7 +15,8 @@
   </div>
 
   <div class="four-col last align-right">
-    <%= link_to "Edit Course", edit_administrators_course_path(@course), class: "btn" %>
+    <p><small><%= link_to "Edit Course", edit_administrators_course_path(@course) %> >></small></p>
+    <%= link_to "Start Course", course_lesson_path(@course, 1), class: "btn" %>
   </div>
 </div>
 


### PR DESCRIPTION
Change the edit course link to be small text above the start course
button on the admin show page for courses.