### PR TITLE
[ REFAC ] Refactor duration to take format

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -38,7 +38,7 @@ class Course < ActiveRecord::Base
     end
   end
 
-  def topics_list
+  def topics_str
     topics.pluck(:title).join(", ")
   end
 
@@ -62,10 +62,10 @@ class Course < ActiveRecord::Base
     lessons.maximum("lesson_order")
   end
 
-  def duration
+  def duration(format="mins")
     total = 0
     lessons.each { |l| total += l.duration }
-    Duration.minutes_str(total)
+    Duration.minutes_str(total, format)
   end
 
 end

--- a/app/models/duration.rb
+++ b/app/models/duration.rb
@@ -7,11 +7,11 @@ class Duration
     "#{m}:#{s}"
   end
 
-  def self.minutes_str(seconds)
-    return "0 mins" if seconds.to_i < 0
+  def self.minutes_str(seconds, format="mins")
+    return "0 #{format}" if seconds.to_i < 0
     m = (seconds / 60) % 60
-    return "1 min" if m == 1
-    "#{m} minutes"
+    return "1 #{format.chomp('s')}" if m == 1
+    "#{m} #{format}"
   end
 
   def self.duration_str_to_int(str)

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -14,12 +14,12 @@
   <div class="eightcol">
     <div class="course-details">
       <div><i class="icon-pencil"></i><%= @course.lessons.count %> Lessons</div>
-      <div><i class="icon-clock"></i><%= @course.duration %></div>
+      <div><i class="icon-clock"></i><%= @course.duration("minutes") %></div>
       <div><i class="icon-plus"></i><%= @course.level %></div>
     </div>
     <%# TODO: Fill in dynamic link when ready %>
     <div><small>Contributed by <%= @course.contributor %>, <%= link_to "Commerce Kitchen", "#" %></small></div>
-    <div><small>Topics: <%= @course.topics_list %></small></div>
+    <div><small>Topics: <%= @course.topics_str %></small></div>
   </div>
 
   <div class="fourcol last align-right">

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -182,6 +182,10 @@ describe Course do
       expect(@course.duration).to eq("0 mins")
     end
 
+    it "should return duration in format if one is passed" do
+      @course.lessons << [@lesson1, @lesson2, @lesson3]
+      expect(@course.duration("minutes")).to eq("7 minutes")
+    end
   end
 
 end


### PR DESCRIPTION
Refactors duration class to take an optional format argument, but has a
default value of "mins", formats should be passed as plural string
ie: "minutes", "hours", "days".