### PR TITLE
[CHG] Fixes search to include level

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,7 +26,7 @@ class Course < ActiveRecord::Base
 
   # PgSearch gem config
   include PgSearch
-  multisearchable against: [:title, :summary, :description, :topics_str]
+  multisearchable against: [:title, :summary, :description, :topics_str, :level]
 
   # Attributes not saved to db, but still needed for validation
   attr_accessor :other_topic, :other_topic_text

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -216,7 +216,7 @@ CREATE TABLE courses (
     summary character varying(156),
     description text,
     contributor character varying,
-    pub_status character varying(2) DEFAULT 'D'::character varying,
+    pub_status character varying DEFAULT 'D'::character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     language_id integer,


### PR DESCRIPTION
Once this is implemented, a ```rake pg_search:multisearch:rebuild[Course]``` will fix the index to work with the new levels search.