### PR TITLE
[CHG] Fixes the home page to show completed courses greyed out.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,6 +18,7 @@
 #  slug           :string
 #  course_order   :integer
 #  pub_date       :datetime
+#  format         :string
 #
 
 class Course < ActiveRecord::Base

--- a/app/views/courses/completed.html.erb
+++ b/app/views/courses/completed.html.erb
@@ -1,8 +1,0 @@
-<h1>Completed Courses</h1>
-
-<% courses_completed = current_user.completed_course_ids %>
-<% if courses_completed.count > 0 %>
-  <%= render partial: "shared/courses/listing" %>
-<% else %>
-  <p> You have not yet completed any courses.</p>
-<% end %>

--- a/app/views/courses/completed.html.erb
+++ b/app/views/courses/completed.html.erb
@@ -2,7 +2,7 @@
 
 <% courses_completed = current_user.completed_course_ids %>
 <% if courses_completed.count > 0 %>
-  <%= render partial: "shared/courses/listing", locals: { courses_completed: courses_completed } %>
+  <%= render partial: "shared/courses/listing" %>
 <% else %>
   <p> You have not yet completed any courses.</p>
 <% end %>

--- a/app/views/courses/your.html.erb
+++ b/app/views/courses/your.html.erb
@@ -7,10 +7,4 @@
   and we'll suggest even more courses.
 </p>
 
-<% if user_signed_in? %>
-  <% courses_completed = current_user.completed_course_ids %>
-<% else %>
-  <% courses_completed = [] %>
-<% end %>
-
-<%= render partial: "shared/courses/listing", locals: { courses_completed: courses_completed } %>
+<%= render partial: "shared/courses/listing" %>

--- a/app/views/shared/courses/_listing.html.erb
+++ b/app/views/shared/courses/_listing.html.erb
@@ -1,3 +1,9 @@
+<% if user_signed_in? %>
+  <% courses_completed = current_user.completed_course_ids %>
+<% else %>
+  <% courses_completed = [] %>
+<% end %>
+
 <div class="container">
 <% @courses.each do |c| %>
     <a class="course-widget <% if courses_completed.include?(c.id) %>completed<% end %>"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,7 +54,8 @@ puts "#{Language.count} languages created."
     pub_status: %w(P D T).sample,
     language_id: Language.first.id,
     level: "Beginner",
-    pub_date: Time.zone.now
+    pub_date: Time.zone.now,
+    format: %w(M D).sample
   )
 end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -18,6 +18,7 @@
 #  slug           :string
 #  course_order   :integer
 #  pub_date       :datetime
+#  format         :string
 #
 
 FactoryGirl.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -18,6 +18,7 @@
 #  slug           :string
 #  course_order   :integer
 #  pub_date       :datetime
+#  format         :string
 #
 
 require "rails_helper"


### PR DESCRIPTION
Also, moves the courses_completed check into the partial, as that’s the
only place I see it typically used. There is a redundant check on the ```views/courses/completed.html.erb``` partial, but I think that's not being used by anything anymore. (It was used in the user's dashboard to view all completed courses, but has been replaced there by ```views/courses/completed_list.html.erb```