### PR TITLE
[CHG] Adds chicago redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   before_action :set_language
   before_action :set_cms_footer_pages
+  before_action :redirect_chicago
   protect_from_forgery with: :exception
 
   layout proc { user_signed_in? ? "user/logged_in" : "application" }
@@ -24,6 +25,13 @@ class ApplicationController < ActionController::Base
 
   def set_cms_footer_pages
     @footer_pages = CmsPage.all
+  end
+
+  def redirect_chicago
+    case request.subdomain
+    when "chicago"
+      redirect_to root_url(subdomain: "chipublib")
+    end
   end
 
   private


### PR DESCRIPTION
This is needed as the CNAME only points to the right server. With this,
they will get redirected to the correct subdomain, which is what we
need. In the future, we can use this with a bit of metaprogramming to
allow people to setup a “main” subdomain and “secondary” subdomains
that redirect to their main subdomain.