### PR TITLE
[BUG] Updating html5sortable to dist 0.3.1

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require select2
+//= require html.sortable
 //= require ckeditor/init
 //= require local_time
 //= require_tree .

--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -4,7 +4,6 @@ $(document).ready(function() {
   // match the event from the ASL file:
   // window.parent.sendLessonCompletedEvent();
   sendLessonCompletedEvent = function() {
-    console.log("It is working????")
     var is_assessment = $("#is_assessment").val() == "true";
     if (!is_assessment) {
       window.location = (window.location.pathname + "/lesson_complete")

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -35,6 +35,6 @@
 @import "components/course_progress";
 @import "components/lesson_block";
 @import "components/search_box";
-// @import "components/sortable_list";
+@import "components/sortable_list";
 @import "components/congratulation_banner";
 @import "scaffolds";

--- a/vendor/assets/javascripts/html.sortable.js
+++ b/vendor/assets/javascripts/html.sortable.js
@@ -1,3 +1,12 @@
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('jquery'));
+  } else {
+    root.sortable = factory(root.jQuery);
+  }
+}(this, function($) {
 /*
  * HTML5 Sortable jQuery Plugin
  * https://github.com/voidberg/html5sortable
@@ -415,19 +424,6 @@ sortable.disable = function(sortable) {
 $.fn.sortable = function(options) {
   return sortable(this, options);
 };
-/* start-testing */
-sortable.__testing = {
-  // add internal methods here for testing purposes
-  _removeSortableEvents: _removeSortableEvents,
-  _removeItemEvents: _removeItemEvents,
-  _removeItemData: _removeItemData,
-  _removeSortableData: _removeSortableData,
-  _listsConnected: _listsConnected,
-  _getOptions: _getOptions,
-  _attachGhost: _attachGhost,
-  _addGhostPos: _addGhostPos,
-  _getGhost: _getGhost,
-  _makeGhost: _makeGhost
-};
-module.exports = sortable;
-/* end-testing */
+
+return sortable;
+}));


### PR DESCRIPTION
We are seeing some javascript errors that indicate that we should be
using a different file for html5sortable. The following bug report
indicates that we should use the file from the "dist" directory.

https://github.com/voidberg/html5sortable/issues/182

This is the latest "released" version (0.3.1) from the dist directory.

~tommy