### PR TITLE
[CHG] Prevent subsite course edit before import

### DIFF
--- a/app/views/admin/courses/_sortable_import_list.html.erb
+++ b/app/views/admin/courses/_sortable_import_list.html.erb
@@ -13,11 +13,11 @@
       <ul class="objects sortable reorderable">
         <% courses.each do |course| %>
           <li class="sortable-item table-row" data-id="<%= course.id %>">
-            <div class="cell"><%= link_to course.title, edit_admin_course_path(course), class: "no_drag_link" %></div>
+            <div class="cell"><%= course.title %></div>
             <div class="cell"><%= course.topics_str %></div>
             <div class="cell"><%= course.language.name %></div>
             <div class="cell">
-              <%= link_to("Import Course", admin_dashboard_add_imported_course_path(course_id: course.id), method: :post) %>
+              <%= link_to "Import Course", admin_dashboard_add_imported_course_path(course_id: course.id), method: :post %>
             </div>
           </li>
         <% end %>

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,7 +3,7 @@
 
 set :bundle_without, %w{integration production test}.join(" ")
 
-set :branch, "release-2.5.1"
+set :branch, "release-2.5.2"
 
 server "dl-stageapp-01.do.lark-it.com",
   user: fetch(:application),


### PR DESCRIPTION
If the subsite has a course to import, but clicks the link and edits
it before importing it, they are editing the main course, not their
imported course, which causes issues.

This change simply removes the link to the edit view, which should be
good enough for now.