### PR TITLE
[CHG] Swap out CMS footer links for static links

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,6 +9,8 @@
               <li><%= link_to page.title, cms_page_path(page) %></li>
             <% end %>
           <% end %>
+          <li><%= link_to "Get DigitalLearn for your Library", static_overview_url(subdomain: "www") %></li>
+          <li><%= link_to "Libraries with DigitalLearn", static_portfolio_url(subdomain: "www") %></li>
         </ul>
       </div>
       <%= render "shared/logo_footer" %>


### PR DESCRIPTION
On two of the pages that we built static landing pages for, swap out
the dynamic cms page link in the footer, for the new page.